### PR TITLE
Update settings.py to not depend on ADMIN_MEDIA_PREFIX

### DIFF
--- a/filebrowser/settings.py
+++ b/filebrowser/settings.py
@@ -13,7 +13,8 @@ try:
     DEFAULT_URL_TINYMCE = tinymce.settings.JS_BASE_URL + '/'
     DEFAULT_PATH_TINYMCE = tinymce.settings.JS_ROOT + '/'
 except ImportError:
-    DEFAULT_URL_TINYMCE = settings.ADMIN_MEDIA_PREFIX + "tinymce/jscripts/tiny_mce/"
+    DEFAULT_URL_TINYMCE = getattr(settings, 'ADMIN_MEDIA_PREFIX',
+                                  os.path.join(settings.STATIC_URL, 'admin/')) + "tinymce/jscripts/tiny_mce/"
     DEFAULT_PATH_TINYMCE = os.path.join(settings.MEDIA_ROOT, 'admin/tinymce/jscripts/tiny_mce/')
 
 # Set to True in order to see the FileObject when Browsing.


### PR DESCRIPTION
ADMIN_MEDIA_PREFIX was removed in Django 1.4. I changed filebrowser's settings.py
so that it does not depend on the existence ADMIN_MEDIA_PREFIX. If ADMIN_MEDIA_PREFIX does not exist in settings.py, it uses STATIC_URL for the admin media root url instead.
