### PR TITLE
Allow for https in MEDIA_URL

### DIFF
--- a/filebrowser/functions.py
+++ b/filebrowser/functions.py
@@ -132,13 +132,15 @@ def url_join(*args):
     
     if args[0].startswith("http://"):
         url = "http://"
+    elif args[0].startswith("https://"):
+        url = "https://"
     else:
         url = "/"
     for arg in args:
         arg = arg.replace("\\", "/")
         arg_split = arg.split("/")
         for elem in arg_split:
-            if elem != "" and elem != "http:":
+            if elem != "" and elem != "http:" and elem != "https:":
                 url = url + elem + "/"
     # remove trailing slash for filenames
     if os.path.splitext(args[-1])[1]:


### PR DESCRIPTION
Fix for https:// in media_url
Same as fix for issue #60 django-filebrowser
https://github.com/sehmaschine/django-filebrowser/issues/60
