### PR TITLE
Update syntax of build_attrs()

### DIFF
--- a/filebrowser/fields.py
+++ b/filebrowser/fields.py
@@ -38,7 +38,7 @@ class FileBrowseWidget(Input):
     def render(self, name, value, attrs=None):
         if value is None:
             value = ""
-        final_attrs = self.build_attrs(attrs, type=self.input_type, name=name)
+        final_attrs = self.build_attrs(attrs, {'type': self.input_type, 'name': name})
         final_attrs['search_icon'] = os.path.join(
             URL_FILEBROWSER_MEDIA, 'img/filebrowser_icon_show.gif'
         )

--- a/filebrowser/fields.py
+++ b/filebrowser/fields.py
@@ -38,7 +38,7 @@ class FileBrowseWidget(Input):
     def render(self, name, value, attrs=None):
         if value is None:
             value = ""
-        final_attrs = self.build_attrs(attrs, {'type': self.input_type, 'name': name})
+        final_attrs = self.build_attrs(self.attrs. attrs, type=self.input_type, name=name)
         final_attrs['search_icon'] = os.path.join(
             URL_FILEBROWSER_MEDIA, 'img/filebrowser_icon_show.gif'
         )
@@ -54,6 +54,17 @@ class FileBrowseWidget(Input):
             except:
                 pass
         return render_to_string(_template() + "custom_field.html", locals())
+
+    def build_attrs(self, base_attrs, extra_attrs=None, **kwargs):
+        """
+        Helper function for building an attribute dictionary.
+        Override Widget.build_attrs to support Django<=1.10 and Django>=1.11
+        at the same time.
+        """
+        attrs = dict(base_attrs, **kwargs)
+        if extra_attrs:
+            attrs.update(extra_attrs)
+        return attrs
 
 
 class FileBrowseFormField(forms.CharField):

--- a/filebrowser/fields.py
+++ b/filebrowser/fields.py
@@ -38,7 +38,7 @@ class FileBrowseWidget(Input):
     def render(self, name, value, attrs=None):
         if value is None:
             value = ""
-        final_attrs = self.build_attrs(self.attrs. attrs, type=self.input_type, name=name)
+        final_attrs = self.build_attrs(self.attrs, attrs, type=self.input_type, name=name)
         final_attrs['search_icon'] = os.path.join(
             URL_FILEBROWSER_MEDIA, 'img/filebrowser_icon_show.gif'
         )


### PR DESCRIPTION
I don't see any branch available for this, so I just make a pull request to master.
If there is a one, I can make a new pull request again.

This is a one line modification to `build_attrs`, which is a change in [django 1.11](https://docs.djangoproject.com/en/2.0/releases/1.11/).
> The signature of private API Widget.build_attrs() changed from extra_attrs=None, **kwargs to base_attrs, extra_attrs=None.

See also:
https://stackoverflow.com/questions/43226914/update-to-1-11-typeerror-build-attrs-takes-at-most-2-arguments-3-given

I think `django 1.8` approaches end of extended support and other people may have same need like me that want o upgrade to next LTS release, that is, 1.11.